### PR TITLE
Fix to allow owner of list to view list that is Friends Only.

### DIFF
--- a/app/Update/CustomList.php
+++ b/app/Update/CustomList.php
@@ -29,21 +29,23 @@ class CustomList
 			$userId = Auth::User()->id;
 
 			$friendsListCacheName = "friendsList_{$userId}";
-			if(!Cache::has($friendsListCacheName) && $userList->privacy == 2)
+			if($userId != $userList->user_id && !Cache::has($friendsListCacheName) && $userList->privacy == 2)
 			{
-					$this->error = "list_no_permission"; return;
+				$this->error = "list_no_permission"; return;
 			}
 			
 			$friendsList = Cache::get($friendsListCacheName);
 
-			if($userId != $userList->user_id) {
-				if(($userList->privacy == 3)
-					|| ($userList->privacy == 2 && !in_array($userList->user->small_id, $friendsList)))
+			if($userId != $userList->user_id)
+			{
+				if(($userList->privacy == 3) ||
+					($userList->privacy == 2 && !in_array($userList->user->small_id, $friendsList)))
 				{
 					$this->error = "list_no_permission"; return;
 				}
 			}
-		} else if($userList->privacy == 2 || $userList->privacy == 3) {
+		} else if($userList->privacy == 2 || $userList->privacy == 3)
+		{
 			$this->error = "list_no_permission"; return;
 		}
 


### PR DESCRIPTION
I made a new account, made a new private list afterwards, then changed the privacy of the list to Friends Only. Now I can't view my own list. I think it's because the Cache does not have my friends list, but the line also isn't checking to see if I'm the owner of the list to begin with. I also fixed subsequent lines to match bracket placement.