### PR TITLE
Added a new feature - Latest VAC bans

### DIFF
--- a/app/Http/Controllers/APIv1/ListController.php
+++ b/app/Http/Controllers/APIv1/ListController.php
@@ -7,6 +7,7 @@ use VacStatus\Http\Requests;
 use VacStatus\Update\MostTracked;
 use VacStatus\Update\LatestTracked;
 use VacStatus\Update\CustomList;
+use VacStatus\Update\LatestVAC;
 
 use VacStatus\Models\User;
 use VacStatus\Models\UserList;
@@ -158,6 +159,18 @@ class ListController extends Controller
 		$return = [
 			'title' => 'Latest Tracked Users',
 			'list' => $latestTracked->getLatestTracked()
+		];
+
+		return $return;
+	}
+
+	public function latestVAC()
+	{
+		$latestVac = new LatestVAC();
+
+		$return = [
+			'title' => 'Latest VAC Banned Users',
+			'list' => $latestVac->getLatestVAC()
 		];
 
 		return $return;

--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -55,6 +55,12 @@ class PagesController extends Controller {
 			->withGrab('latest');
 	}
 
+	public function latestVACPage()
+	{
+		return view('pages/list')
+			->withGrab('latest_vac');
+	}
+
 	public function customListPage($listId)
 	{
 		return view('pages/list')

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -35,6 +35,11 @@ get('/list/latest', [
 	'uses' => 'PagesController@latestTrackedPage'
 ]);
 
+get('/list/latest/vac', [
+	'as' => 'tracked.latest_vac',
+	'uses' => 'PagesController@latestVACPage'
+]);
+
 get('/list/{listId}', [
 	'as' => 'tracked.custom',
 	'uses' => 'PagesController@customListPage'
@@ -127,6 +132,11 @@ Route::group(['prefix' => 'api'], function()
 			get('/latest', [
 				'as' => 'api.v1.tracked.latest',
 				'uses' => 'ListController@latestTracked'
+			]);
+
+			get('/latest_vac', [
+				'as' => 'api.v1.tracked.latest_vac',
+				'uses' => 'ListController@latestVAC'
 			]);
 
 			get('/', [

--- a/app/Update/LatestVAC.php
+++ b/app/Update/LatestVAC.php
@@ -26,10 +26,10 @@ class LatestVAC extends BaseUpdate
 
 	public function getLatestVAC()
 	{
-		// if(!$this->canUpdate()) {
-		// 	$return = $this->grabCache();
-		// 	if($return !== false) return $return;
-		// }
+		if(!$this->canUpdate()) {
+			$return = $this->grabCache();
+			if($return !== false) return $return;
+		}
 
 		return $this->grabFromDB();
 	}

--- a/app/Update/LatestVAC.php
+++ b/app/Update/LatestVAC.php
@@ -1,0 +1,111 @@
+<?php namespace VacStatus\Update;
+
+use VacStatus\Update\BaseUpdate;
+use VacStatus\Update\MultiProfile;
+
+use Cache;
+use Carbon;
+use DateTime;
+
+use VacStatus\Models\UserListProfile;
+
+use VacStatus\Steam\Steam;
+
+/*
+ * This is almost an exact copy of LatestTracked.php. The only thing that's different is
+ * I am now filtering where vac_banned_on IS NOT NULL AND vac > 0 ORDER BY vac_banned_on DESC
+ */
+
+class LatestVAC extends BaseUpdate
+{
+	function __construct()
+	{
+		$this->cacheLength = 30;
+		$this->cacheName = "latestVAC";
+	}
+
+	public function getLatestVAC()
+	{
+		// if(!$this->canUpdate()) {
+		// 	$return = $this->grabCache();
+		// 	if($return !== false) return $return;
+		// }
+
+		return $this->grabFromDB();
+	}
+
+	private function grabFromDB()
+	{
+		$userListProfiles = UserListProfile::orderBy('user_list_profile.id', 'desc')
+			->take(20)
+			->leftjoin('profile', 'user_list_profile.profile_id', '=', 'profile.id')
+			->leftjoin('profile_ban', 'profile.id', '=', 'profile_ban.profile_id')
+			->leftjoin('users', 'profile.small_id', '=', 'users.small_id')
+			->whereNull('user_list_profile.deleted_at')
+			->whereNotNull('profile_ban.vac_banned_on')
+			->where('profile_ban.vac', '>', '0')
+			->orderBy('profile_ban.vac_banned_on', 'DESC')
+			->groupBy('profile.id')
+			->get([
+				'profile.id',
+				'profile.display_name',
+				'profile.avatar_thumb',
+				'profile.small_id',
+
+				'profile_ban.vac',
+				'profile_ban.vac_banned_on',
+				'profile_ban.community',
+				'profile_ban.trade',
+
+				'users.site_admin',
+				'users.donation',
+				'users.beta',
+
+				\DB::raw('max(user_list_profile.created_at) as created_at'),
+				\DB::raw('count(user_list_profile.id) as total'),
+			]);
+
+		$profileIds = [];
+		foreach($userListProfiles as $userListProfile)
+		{
+			$profileIds[] = $userListProfile->id;
+		}
+
+		$all = UserListProfile::whereIn('profile_id', $profileIds)
+			->orderBy('id', 'desc')
+			->get();
+
+		$return = [];
+
+		foreach($userListProfiles as $userListProfile)
+		{
+			$vacBanDate = new DateTime($userListProfile->vac_banned_on);
+
+			$return[] = [
+				'id'			=> $userListProfile->id,
+				'display_name'	=> $userListProfile->display_name,
+				'avatar_thumb'	=> $userListProfile->avatar_thumb,
+				'small_id'		=> $userListProfile->small_id,
+				'steam_64_bit'	=> Steam::to64Bit($userListProfile->small_id),
+				'vac'			=> $userListProfile->vac,
+				'vac_banned_on'	=> $vacBanDate->format("M j Y"),
+				'community'		=> $userListProfile->community,
+				'trade'			=> $userListProfile->trade,
+				'site_admin'	=> $userListProfile->site_admin?:0,
+				'donation'		=> $userListProfile->donation?:0,
+				'beta'			=> $userListProfile->beta?:0,
+				'times_added'	=> [
+					'number' => $userListProfile->total,
+					'time' => (new DateTime($userListProfile->created_at))->format("M j Y")
+				],
+			];
+		}
+
+		$multiProfile = new MultiProfile($return);
+		$return = $multiProfile->run();
+
+		$this->updateCache($return);
+		
+		return $return;
+	}
+}

--- a/public/js/pages/listPortal.js
+++ b/public/js/pages/listPortal.js
@@ -133,7 +133,8 @@ var ListPortal = React.createClass({displayName: "ListPortal",
 					React.createElement("div", {className: "special-list"}, 
 						React.createElement("h3", null, "Special Lists"), 
 						React.createElement("a", {href: "/list/most"}, "Most Tracked Users"), 
-						React.createElement("a", {href: "/list/latest"}, "Latest Added Users")
+						React.createElement("a", {href: "/list/latest"}, "Latest Added Users"),
+						React.createElement("a", {href: "/list/latest/vac"}, "Latest VAC Banned Users")
 					)
 				), 
 				React.createElement("div", {className: "col-xs-12"}, 

--- a/public/js/pages/listPortal.js
+++ b/public/js/pages/listPortal.js
@@ -133,8 +133,8 @@ var ListPortal = React.createClass({displayName: "ListPortal",
 					React.createElement("div", {className: "special-list"}, 
 						React.createElement("h3", null, "Special Lists"), 
 						React.createElement("a", {href: "/list/most"}, "Most Tracked Users"), 
-						React.createElement("a", {href: "/list/latest"}, "Latest Added Users"),
-						React.createElement("a", {href: "/list/latest/vac"}, "Latest VAC Banned Users")
+						React.createElement("a", {href: "/list/latest"}, "Latest Added Users"), 
+						React.createElement("a", {href: "/list/latest/vac"}, "Latest VAC Bans")
 					)
 				), 
 				React.createElement("div", {className: "col-xs-12"}, 

--- a/resources/assets/jsx/pages/listPortal.jsx
+++ b/resources/assets/jsx/pages/listPortal.jsx
@@ -134,6 +134,7 @@ var ListPortal = React.createClass({
 						<h3>Special Lists</h3>
 						<a href="/list/most">Most Tracked Users</a>
 						<a href="/list/latest">Latest Added Users</a>
+						<a href="/list/latest/vac">Latest VAC Bans</a>
 					</div>
 				</div>
 				<div className="col-xs-12">

--- a/resources/views/layout/header.blade.php
+++ b/resources/views/layout/header.blade.php
@@ -36,6 +36,9 @@
 				<li class="@setActiveLink('tracked.latest')">
 					<a href="{{ route('tracked.latest') }}">Latest Added</a>
 				</li>
+				<li class="@setActiveLink('tracked.latest_vac')">
+					<a href="{{ route('tracked.latest_vac') }}">Latest VAC Bans</a>
+				</li>
 			@endif
 				<li class="@setActiveLink('search')">
 					<a href="#searchModal" data-toggle="modal">Look Up Users</a>

--- a/resources/views/pages/listPortal.blade.php
+++ b/resources/views/pages/listPortal.blade.php
@@ -9,6 +9,7 @@
 						<h3>Special Lists</h3>
 						<a href="/list/most">Most Tracked Users</a>
 						<a href="/list/latest">Latest Added Users</a>
+						<a href="/list/latest/vac">Latest VAC Banned Users</a>
 					</div>
 				</div>
 				<div class="col-xs-12">


### PR DESCRIPTION
I thought this may be an interesting feature to have. It's a list just like Latest Tracked Users that allows you to see recently tracked VAC bans. On my local copy of VacStatus, all works well. 

I'd like your thoughts on it @jung3o. Do you think this would be an interesting feature to have?